### PR TITLE
Update to Spigot API 1.21.5 and Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>DiamondBanking</name>
 
     <properties>
-        <java.version>1.11</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -55,8 +55,8 @@
 
     <repositories>
         <repository>
-            <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>sonatype</id>
@@ -70,9 +70,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Changes:
- I've updated the core server API dependency from Paper API to Spigot API version 1.21.5-R0.1-SNAPSHOT. This was done to resolve issues with accessing the PaperMC Maven repository.
- I've updated the Java version property from 1.11 to 21.
- I've updated `maven-compiler-plugin` to version 3.13.0.
- I've updated `maven-shade-plugin` to version 3.6.0.
- I've removed Paper-specific `paperweight-mappings-namespace` configuration as it's not applicable when using Spigot API directly.
- I've adjusted the repository list in `pom.xml` to remove PaperMC repo and ensure SpigotMC repo is present.

The project now successfully builds against Spigot API 1.21.5.