### PR TITLE
Refactor: Rewrite DiamondBanking plugin to remove configuration and s…

### DIFF
--- a/src/main/java/net/recelate/diamondbanking/DiamondBanking.java
+++ b/src/main/java/net/recelate/diamondbanking/DiamondBanking.java
@@ -1,10 +1,10 @@
 package net.recelate.diamondbanking;
 
 import java.util.ArrayList;
+import java.util.HashMap; // Added for addItem return type
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.Material;
@@ -21,7 +21,7 @@ public final class DiamondBanking extends JavaPlugin
 {
     private static final Logger log = Logger.getLogger("Minecraft");
     private static Economy econ = null;
-    private static FileConfiguration config = null;
+    private static final int DIAMOND_WORTH = 1;
 
     @Override
     public void onEnable()
@@ -32,42 +32,12 @@ public final class DiamondBanking extends JavaPlugin
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
-
-        // Config handling starts
-        this.saveDefaultConfig(); // Ensures config.yml from JAR is in plugin's data folder if not already.
-        config = this.getConfig(); // Load it.
-
-        boolean defaultsApplied = false;
-        if (!config.contains("DiamondWorth")) {
-            getLogger().info("DiamondWorth not found in config.yml, setting default value (1).");
-            config.set("DiamondWorth", 1);
-            defaultsApplied = true;
-        }
-        // Ensure other defaults are set if this is a fresh config or they are missing
-        if (!config.contains("AllowLittering")) {
-            // Assuming 'AllowLittering' should also be explicitly defaulted if missing
-            // If DiamondWorth was missing, it's a good sign other defaults might be too.
-            getLogger().info("AllowLittering not found in config.yml, setting default value (true).");
-            config.set("AllowLittering", true);
-            defaultsApplied = true;
-        }
-
-        if (defaultsApplied) {
-            this.saveConfig(); // Save these initial defaults if any were applied.
-        }
-        // Config handling ends
-        config.addDefault("DiamondWorth", 1);
     }
 
     @Override
     public void onDisable()
     {
         log.info(String.format("[%s] Disabled Version %s", getDescription().getName(), getDescription().getVersion()));
-        if( config != null )
-        {
-            // config.options().copyDefaults(true); // Ensure this line is removed
-            saveConfig();
-        }
     }
 
     @Override
@@ -110,7 +80,7 @@ public final class DiamondBanking extends JavaPlugin
         if( plr.getInventory().getItemInMainHand().getType() == Material.DIAMOND_BLOCK )
             amount *= 9;
 
-        EconomyResponse r = econ.depositPlayer(plr, amount * config.getInt("DiamondWorth"));
+        EconomyResponse r = econ.depositPlayer(plr, amount * DIAMOND_WORTH);
         if( r.transactionSuccess() )
         {
             plr.getInventory().getItemInMainHand().setAmount(0);
@@ -133,95 +103,70 @@ public final class DiamondBanking extends JavaPlugin
         }
 
         int amount = Integer.parseInt(args[0]);
-        if( econ.getBalance(plr) < amount * config.getInt("DiamondWorth") )
+        if( econ.getBalance(plr) < amount * DIAMOND_WORTH )
         {
             plr.sendMessage("You do not have enough money to do that!");
             return true;
         }
 
-        List<Integer> amounts = new ArrayList<Integer>();
+        // Calculate available inventory space
+        int availableSpace = 0;
+        for (ItemStack item : plr.getInventory().getStorageContents()) {
+            if (item == null) {
+                availableSpace += Material.DIAMOND.getMaxStackSize();
+            } else if (item.getType() == Material.DIAMOND) {
+                availableSpace += item.getMaxStackSize() - item.getAmount();
+            }
+        }
 
-        for( int x = 0; x < amount / plr.getInventory().getMaxStackSize(); x++ )
-            amounts.add(plr.getInventory().getMaxStackSize());
-        amounts.add(amount % plr.getInventory().getMaxStackSize());
+        if (amount > availableSpace) {
+            if (availableSpace == 0) {
+                plr.sendMessage("You do not have enough inventory space to withdraw any diamonds.");
+                return true;
+            }
+            plr.sendMessage(String.format("You only have enough space for %d diamonds. Withdrawing that amount instead.", availableSpace));
+            amount = availableSpace;
+        }
 
-        int emptyCount = 0;
-        for( ItemStack stack : plr.getInventory().getContents() )
-            if( stack == null )
-                emptyCount++;
-
-        if( !config.getBoolean("AllowLittering") && emptyCount < amounts.size() )
-        {
-            plr.sendMessage("You do not have enough free space to do that!");
+        EconomyResponse r = econ.withdrawPlayer(plr, amount * DIAMOND_WORTH);
+        if (!r.transactionSuccess()) {
+            plr.sendMessage(String.format("An error occurred during withdrawal: %s", r.errorMessage));
             return true;
         }
 
-        int refundAmount = 0;
+        int diamondsToGive = amount;
+        int diamondsActuallyGiven = 0;
 
-        EconomyResponse r = econ.withdrawPlayer(plr, amount * config.getInt("DiamondWorth"));
-        if( r.transactionSuccess() )
-        {
-            for(Integer amt : amounts )
-            {
-                ItemStack diamonds = new ItemStack(Material.DIAMOND, amt);
-                if( plr.getInventory().firstEmpty() != -1 )
-                    plr.getInventory().addItem(diamonds);
-                else if( config.getBoolean("AllowLittering") )
-                    plr.getWorld().dropItem(plr.getLocation(), diamonds);
-                else
-                {
-                    if( plr.getEnderChest().firstEmpty() != -1 )
-                        plr.getEnderChest().addItem(diamonds);
-                    else
-                        refundAmount += diamonds.getAmount();
-                }
-            }
-        }
-        else
-            plr.sendMessage(String.format("An error occured: %s", r.errorMessage));
-
-        int refundCost = refundAmount * config.getInt("DiamondWorth");
-        if( refundAmount != 0 )
-        {
-            r = econ.depositPlayer(plr, refundCost);
-            if( !r.transactionSuccess() )
-            {
-                log.severe(String.format("Failed to refund player (%s) for %s", plr.getName(), econ.format(r.amount)));
-            }
+        if (diamondsToGive > 0) {
+            ItemStack diamonds = new ItemStack(Material.DIAMOND, diamondsToGive);
+            HashMap<Integer, ItemStack> notAdded = plr.getInventory().addItem(diamonds);
+            diamondsActuallyGiven = diamondsToGive - (notAdded.isEmpty() ? 0 : notAdded.get(0).getAmount());
+            diamondsToGive -= diamondsActuallyGiven;
         }
 
-        plr.sendMessage(String.format("You have withdrew %d Diamonds, for %s. Your balance is now %s",
-                amount-refundAmount, econ.format((amount * config.getInt("DiamondWorth") - refundCost)), econ.format(econ.getBalance(plr))));
+        if (diamondsToGive > 0) {
+            ItemStack remainingDiamondsForEnderChest = new ItemStack(Material.DIAMOND, diamondsToGive);
+            HashMap<Integer, ItemStack> notAddedToEnderChest = plr.getEnderChest().addItem(remainingDiamondsForEnderChest);
+            int diamondsGivenToEnderChest = diamondsToGive - (notAddedToEnderChest.isEmpty() ? 0 : notAddedToEnderChest.get(0).getAmount());
+            diamondsActuallyGiven += diamondsGivenToEnderChest;
+            diamondsToGive -= diamondsGivenToEnderChest;
+        }
+
+        int refundAmount = diamondsToGive;
+        if (refundAmount > 0) {
+            int refundValue = refundAmount * DIAMOND_WORTH;
+            econ.depositPlayer(plr, refundValue); // Refund the value of diamonds that couldn't be placed
+            plr.sendMessage(String.format("Refunded %s for %d diamonds that could not be placed in your inventory or ender chest.", econ.format(refundValue), refundAmount));
+        }
+
+        plr.sendMessage(String.format("You have withdrawn %d Diamonds, for %s. Your balance is now %s",
+                diamondsActuallyGiven, econ.format(diamondsActuallyGiven * DIAMOND_WORTH), econ.format(econ.getBalance(plr))));
 
         return true;
     }
 
     public void reloadPluginConfig(CommandSender sender) {
-        // Reload the configuration from disk
-        this.reloadConfig();
-        // The 'config' object is now updated with values from config.yml
-
-        // Re-apply default setting logic (similar to onEnable)
-        // This ensures that if a user manually deletes a key from config.yml and reloads,
-        // the default value is reinstated and saved.
-        boolean defaultsApplied = false;
-        if (!config.contains("DiamondWorth")) {
-            getLogger().info("DiamondWorth not found in config.yml during reload, setting default value (1) and saving.");
-            config.set("DiamondWorth", 1);
-            defaultsApplied = true;
-        }
-        if (!config.contains("AllowLittering")) {
-            getLogger().info("AllowLittering not found in config.yml during reload, setting default value (true) and saving.");
-            config.set("AllowLittering", true);
-            defaultsApplied = true;
-        }
-
-        if (defaultsApplied) {
-            this.saveConfig(); // Save if any defaults were applied
-            sender.sendMessage("§aDiamondBanking configuration reloaded. Missing values were reset to defaults and saved.");
-        } else {
-            sender.sendMessage("§aDiamondBanking configuration reloaded successfully.");
-        }
+        sender.sendMessage("§aDiamondBanking uses fixed settings and does not require a reload.");
     }
 
     private boolean setupEconomy()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,0 @@
-DiamondWorth: 1
-AllowLittering: true


### PR DESCRIPTION
…implify logic.

This commit completely rewrites the DiamondBanking plugin:

- Removes all file-based configuration (`config.yml`).
- Hardcodes the value of one diamond to $1.
- Simplifies the `/dbreload` command, as configuration is no longer used.
- Updates the `/withdraw` command logic:
    - Checks player inventory space before withdrawal.
    - If space is insufficient, withdraws only what fits.
    - Attempts to use the Ender Chest if the main inventory is full.
    - Refunds any amount that cannot be given to the player.
    - No longer drops items on the ground (removes "AllowLittering" concept).
- Ensures Vault integration remains for economy operations.